### PR TITLE
Add example notebook for ElaLoRA with Phi‑4‑mini

### DIFF
--- a/train_phi4mini_elalora.ipynb
+++ b/train_phi4mini_elalora.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "177b8cb0",
+   "metadata": {},
+   "source": [
+    "# Fine-Tuning `Phi-4-mini` mit ElaLoRA\n",
+    "\n",
+    "Dieses Notebook zeigt, wie sich das Repository [ElaLoRA](https://github.com/microsoft/ElaLoRA) nutzen lässt, um `microsoft/Phi-4-mini-instruct` mit ElaLoRA zu trainieren. Die Schritte orientieren sich an den Beispielen im Repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dc8c18d",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "Zunächst werden die benötigten Pakete installiert und das lokale `loralib`-Package eingebunden."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36d6efdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install transformers datasets accelerate -q\n",
+    "!pip install -e ./loralib\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2ba473c",
+   "metadata": {},
+   "source": [
+    "## Modell und Tokenizer laden\n",
+    "Das vortrainierte Modell `microsoft/Phi-4-mini-instruct` wird von Hugging Face geladen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40637792",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "import torch\n",
+    "model_id = 'microsoft/Phi-4-mini-instruct'\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_id)\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8c25447",
+   "metadata": {},
+   "source": [
+    "## ElaLoRA in das Modell integrieren\n",
+    "Relevante `nn.Linear`-Schichten werden durch `loralib.SVDLinear` ersetzt und der `RankAllocator` initialisiert."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba02f1d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import loralib as lora\n",
+    "from loralib.elalora import RankAllocator, SVDLinear\n",
+    "\n",
+    "replace_modules = ['q_proj','k_proj','v_proj','o_proj','fc1','fc2']\n",
+    "for name, module in model.named_modules():\n",
+    "    if any(m in name for m in replace_modules) and isinstance(module, torch.nn.Linear):\n",
+    "        parent_name = name.rsplit('.',1)[0]\n",
+    "        parent = model.get_submodule(parent_name)\n",
+    "        new_module = SVDLinear(module.in_features, module.out_features, r=8, lora_alpha=16)\n",
+    "        new_module.weight.data = module.weight.data\n",
+    "        if module.bias is not None:\n",
+    "            new_module.bias.data = module.bias.data\n",
+    "        setattr(parent, name.split('.')[-1], new_module)\n",
+    "\n",
+    "lora.mark_only_lora_as_trainable(model)\n",
+    "rankallocator = RankAllocator(\n",
+    "    model,\n",
+    "    lora_r=8,\n",
+    "    target_rank=8,\n",
+    "    init_warmup=300,\n",
+    "    final_warmup=500,\n",
+    "    mask_interval=50,\n",
+    "    beta1=0.85,\n",
+    "    beta2=0.85,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7520f4e",
+   "metadata": {},
+   "source": [
+    "## Datensatz vorbereiten\n",
+    "Als Beispiel dient das `xsum`-Datenset für Zusammenfassungen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c36a865",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "dataset = load_dataset('xsum')\n",
+    "\n",
+    "max_length = 512\n",
+    "\n",
+    "def preprocess_function(examples):\n",
+    "    inputs = examples['document']\n",
+    "    model_inputs = tokenizer(inputs, max_length=max_length, truncation=True)\n",
+    "    with tokenizer.as_target_tokenizer():\n",
+    "        labels = tokenizer(examples['summary'], max_length=64, truncation=True)\n",
+    "    model_inputs['labels'] = labels['input_ids']\n",
+    "    return model_inputs\n",
+    "\n",
+    "processed_datasets = dataset.map(preprocess_function, batched=True, remove_columns=dataset['train'].column_names)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72f635b2",
+   "metadata": {},
+   "source": [
+    "## Training konfigurieren und starten\n",
+    "Das Training orientiert sich an `run_summarization_no_trainer.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f08fae16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import TrainingArguments, Trainer, DataCollatorForSeq2Seq\n",
+    "\n",
+    "data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)\n",
+    "\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir='./phi4-elalora',\n",
+    "    per_device_train_batch_size=2,\n",
+    "    per_device_eval_batch_size=2,\n",
+    "    num_train_epochs=1,\n",
+    "    logging_steps=10,\n",
+    "    save_steps=100,\n",
+    "    learning_rate=5e-5,\n",
+    "    fp16=True,\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    args=training_args,\n",
+    "    train_dataset=processed_datasets['train'],\n",
+    "    eval_dataset=processed_datasets['validation'],\n",
+    "    data_collator=data_collator,\n",
+    ")\n",
+    "\n",
+    "for step, batch in enumerate(trainer.get_train_dataloader()):\n",
+    "    outputs = trainer.model(**batch)\n",
+    "    loss = outputs.loss\n",
+    "    loss.backward()\n",
+    "    rankallocator.update_and_mask(trainer.model, step)\n",
+    "    trainer.optimizer.step()\n",
+    "    trainer.lr_scheduler.step()\n",
+    "    trainer.optimizer.zero_grad()\n",
+    "    if step > 10:\n",
+    "        break\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "436fb01a",
+   "metadata": {},
+   "source": [
+    "## Weitere Schritte\n",
+    "Nach dem Training können die LoRA-Gewichte mit `loralib.utils.lora_state_dict` gespeichert werden."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `train_phi4mini_elalora.ipynb` showing how to train Microsoft Phi‑4‑mini using ElaLoRA

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687158f76648833389037e77e1187a3e